### PR TITLE
Fix swatch display in product information

### DIFF
--- a/snippets/product-siblings.liquid
+++ b/snippets/product-siblings.liquid
@@ -1,6 +1,17 @@
 {%- assign metafields = metafields | default: false -%}
 {%- assign show_siblings = false -%}
-{%- assign sibs_collection = collections[block.settings.siblings_collection].products -%}
+
+{%- comment -%} Get siblings collection from block settings or metafields {%- endcomment -%}
+{%- assign sibs_collection = blank -%}
+{%- if block.settings.siblings_collection != blank -%}
+  {%- assign sibs_collection = collections[block.settings.siblings_collection].products -%}
+{%- elsif product.metafields.theme.siblings.value != blank -%}
+  {%- assign sibs_collection = collections[product.metafields.theme.siblings.value].products -%}
+{%- elsif product.metafields.theme.sibling_products.value != blank -%}
+  {%- assign sibs_collection = product.metafields.theme.sibling_products.value -%}
+{%- endif -%}
+
+{%- comment -%} Get sibling color from block settings or metafields {%- endcomment -%}
 {%- assign sibling_color = block.settings.sibling_color 
   | default: product.metafields.theme.sibling_color.value 
   | default: product.metafields.theme.sibling_colour.value 
@@ -9,15 +20,26 @@
   | default: product.metafields.theme.siblings_colors.value 
   | default: product.metafields.theme.siblings_colours.value -%}
 
-{%- if metafields -%}
-  {%- assign sibs_collection = product.metafields.theme.sibling_products.value 
-    | default: collections[product.metafields.theme.siblings.value].products -%}
-{%- endif -%}
-
-{%- if metafields and sibs_collection != blank -%}
-  {%- assign show_siblings = true -%}
-{%- elsif metafields == false and sibs_collection.size > 0 -%}
-  {%- assign show_siblings = true -%}
+{%- comment -%} Show siblings if we have a collection with products {%- endcomment -%}
+{%- if sibs_collection != blank and sibs_collection.size > 0 -%}
+  {%- comment -%} Count products with valid color metafields {%- endcomment -%}
+  {%- assign valid_siblings_count = 0 -%}
+  {%- for sib_product in sibs_collection limit: 50 -%}
+    {%- assign test_color = sib_product.metafields.theme.sibling_color.value
+      | default: sib_product.metafields.theme.sibling_colour.value
+      | default: sib_product.metafields.theme.siblings_color.value
+      | default: sib_product.metafields.theme.siblings_colour.value
+      | default: sib_product.metafields.theme.siblings_colors.value
+      | default: sib_product.metafields.theme.siblings_colours.value -%}
+    {%- if test_color != blank -%}
+      {%- assign valid_siblings_count = valid_siblings_count | plus: 1 -%}
+    {%- endif -%}
+  {%- endfor -%}
+  
+  {%- comment -%} Show if we have at least one product with color info {%- endcomment -%}
+  {%- if valid_siblings_count > 0 -%}
+    {%- assign show_siblings = true -%}
+  {%- endif -%}
 {%- endif -%}
 
 {%- assign color_picker_size = block.settings.color_picker_size | default: 'regular' -%}
@@ -48,28 +70,58 @@
             | default: sib_product.metafields.theme.siblings_colours.value
             | strip -%}
 
+          {%- comment -%} Skip products without color information {%- endcomment -%}
+          {%- if sibling_color_value == blank -%}
+            {%- continue -%}
+          {%- endif -%}
+
           {%- assign color_left = '' -%}
           {%- assign color_right = '' -%}
+          {%- assign has_swatch_color = false -%}
 
+          {%- comment -%} Handle dual colors separated by & {%- endcomment -%}
           {%- if sibling_color_value contains '&' -%}
             {%- assign parts = sibling_color_value | split: '&' -%}
             {%- assign left_title = parts[0] | strip -%}
             {%- assign right_title = parts[1] | strip -%}
 
-            {%- assign left_metal = shop.metaobjects['metal'].values | where: 'title', left_title | first -%}
-            {%- if left_metal and left_metal.colour -%}
-              {%- assign color_left = left_metal.colour -%}
+            {%- comment -%} Try to get colors from metaobjects first {%- endcomment -%}
+            {%- if shop.metaobjects['metal'] -%}
+              {%- assign left_metal = shop.metaobjects['metal'].values | where: 'title', left_title | first -%}
+              {%- if left_metal and left_metal.colour -%}
+                {%- assign color_left = left_metal.colour -%}
+                {%- assign has_swatch_color = true -%}
+              {%- endif -%}
+
+              {%- assign right_metal = shop.metaobjects['metal'].values | where: 'title', right_title | first -%}
+              {%- if right_metal and right_metal.colour -%}
+                {%- assign color_right = right_metal.colour -%}
+                {%- assign has_swatch_color = true -%}
+              {%- endif -%}
             {%- endif -%}
 
-            {%- assign right_metal = shop.metaobjects['metal'].values | where: 'title', right_title | first -%}
-            {%- if right_metal and right_metal.colour -%}
-              {%- assign color_right = right_metal.colour -%}
-            {%- endif -%}
+            {%- comment -%} Fallback: try to use color names directly if metaobjects don't exist {%- endcomment -%}
+            {%- unless has_swatch_color -%}
+              {%- assign color_left = left_title | downcase -%}
+              {%- assign color_right = right_title | downcase -%}
+              {%- assign has_swatch_color = true -%}
+            {%- endunless -%}
+
           {%- else -%}
-            {%- assign single_metal = shop.metaobjects['metal'].values | where: 'title', sibling_color_value | first -%}
-            {%- if single_metal and single_metal.colour -%}
-              {%- assign color_left = single_metal.colour -%}
+            {%- comment -%} Single color handling {%- endcomment -%}
+            {%- if shop.metaobjects['metal'] -%}
+              {%- assign single_metal = shop.metaobjects['metal'].values | where: 'title', sibling_color_value | first -%}
+              {%- if single_metal and single_metal.colour -%}
+                {%- assign color_left = single_metal.colour -%}
+                {%- assign has_swatch_color = true -%}
+              {%- endif -%}
             {%- endif -%}
+
+            {%- comment -%} Fallback: use color name directly if metaobject doesn't exist {%- endcomment -%}
+            {%- unless has_swatch_color -%}
+              {%- assign color_left = sibling_color_value | downcase -%}
+              {%- assign has_swatch_color = true -%}
+            {%- endunless -%}
           {%- endif -%}
 
           <label
@@ -92,5 +144,22 @@
     {%- endif -%}
   </div>
 {%- elsif request.design_mode -%}
-  <div {{ block.shopify_attributes }}></div>
+  <div {{ block.shopify_attributes }}>
+    {%- comment -%} Debug information for theme editor {%- endcomment -%}
+    <div style="padding: 10px; background: #f0f0f0; border: 1px solid #ccc; margin: 10px 0;">
+      <strong>Siblings Block Debug:</strong><br>
+      Collection Handle: {{ block.settings.siblings_collection | default: product.metafields.theme.siblings.value | default: 'Not set' }}<br>
+      Sibling Color: {{ sibling_color | default: 'Not set' }}<br>
+      Collection Products: {{ sibs_collection.size | default: 0 }}<br>
+      Valid Siblings: {{ valid_siblings_count | default: 0 }}<br>
+      Show Siblings: {{ show_siblings }}<br>
+      {%- if sibs_collection.size > 0 -%}
+        Products: 
+        {%- for sib in sibs_collection limit: 5 -%}
+          {{ sib.title }}{% unless forloop.last %}, {% endunless %}
+        {%- endfor -%}
+        {%- if sibs_collection.size > 5 -%}...{%- endif -%}
+      {%- endif -%}
+    </div>
+  </div>
 {%- endif -%}


### PR DESCRIPTION
Fix inconsistent swatch display in the product siblings block by improving collection loading, adding color mapping fallbacks, and enhancing debug capabilities.

Previously, swatches failed to render for some products due to inconsistent collection loading from block settings or metafields, a lack of fallback when `shop.metaobjects['metal']` was not configured for color mapping, and no validation to ensure products actually had color metafields. This PR resolves these issues by standardizing collection retrieval, providing a fallback to use color names directly as CSS values, validating products for color metafields, and adding comprehensive debug information for easier troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-8024ecf8-6ff7-440b-90bb-d9c9057a55b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8024ecf8-6ff7-440b-90bb-d9c9057a55b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

