### PR TITLE
Fix liquid syntax error in product siblings

### DIFF
--- a/snippets/product-siblings.liquid
+++ b/snippets/product-siblings.liquid
@@ -127,7 +127,13 @@
         {%- endfor -%}
       </fieldset>
       
-      {%- if debug_mode and (products_without_color > 0 or products_with_color == 0) -%}
+      {%- assign show_debug = false -%}
+      {%- if debug_mode -%}
+        {%- if products_without_color > 0 or products_with_color == 0 -%}
+          {%- assign show_debug = true -%}
+        {%- endif -%}
+      {%- endif -%}
+      {%- if show_debug -%}
         <div class="product-siblings-debug" style="background: #fff3cd; border: 1px solid #ffeaa7; padding: 10px; margin: 10px 0; border-radius: 3px; color: #856404; font-size: 12px;">
           <strong>⚠️ Siblings Debug Info:</strong><br>
           {%- if products_with_color == 0 -%}


### PR DESCRIPTION
Fix Liquid syntax error in `snippets/product-siblings.liquid` by simplifying a complex conditional statement.

---
<a href="https://cursor.com/background-agent?bcId=bc-f25e48f0-0d2d-41c5-b43b-cb1bdbc4d0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f25e48f0-0d2d-41c5-b43b-cb1bdbc4d0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

