### PR TITLE
Product grid color swatches

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -224,7 +224,7 @@ if (!customElements.get('product-card')) {
 
         swatch.addEventListener('mouseover', () => {
           [].forEach.call(swatch_list, function (el) {
-            el.classList.remove('active');
+            el.closest('.product-card-swatch-item').classList.remove('active');
           });
           if (image) {
             if (swatch.dataset.srcset) {
@@ -234,10 +234,10 @@ if (!customElements.get('product-card')) {
             }
           }
           if (this.size_options) {
-            this.current_options[this.color_index] = swatch.querySelector('span').innerText;
+            this.current_options[this.color_index] = swatch.querySelector('.product-card-swatch-name').innerText;
             this.updateMasterId();
           }
-          swatch.classList.add('active');
+          swatch.closest('.product-card-swatch-item').classList.add('active');
         });
         swatch.addEventListener('click', function (evt) {
           window.location.href = this.dataset.href;

--- a/assets/product-grid.css
+++ b/assets/product-grid.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 
 
-.product-card .product-card--featured-image .product-secondary-images-nav li, .product-card-sizes--size, .product-card-sizes--size:before, .product-card-swatches, .product-card-swatches .product-card-swatch, .product-card-swatches--title {
+.product-card .product-card--featured-image .product-secondary-images-nav li, .product-card-sizes--size, .product-card-sizes--size:before, .product-card-swatches, .product-card-swatch-item, .product-card-swatches .product-card-swatch, .product-card-swatches--title {
   transition: all 0.25s cubic-bezier(0.104, 0.204, 0.492, 1); }
 
 .no-js .product-card .product-card-quickview--button, .product-card .no-js .product-card-quickview--button {
@@ -371,39 +371,64 @@
       .product-card-sizes--size.loading > span {
         opacity: 0; }
   .product-card-swatches {
-    line-height: 0;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     transform: translateY(100%); }
-    .product-card-swatches .product-card-swatch {
-      display: inline-flex;
+    .product-card-swatch-item {
+      display: flex;
       margin: 0;
-      width: 18px;
-      height: 18px;
-      border-radius: 9px;
-      padding: 3px;
-      position: relative;
-      cursor: pointer; }
-      .product-card-swatches .product-card-swatch:after {
-        content: "";
-        display: block;
-        position: absolute;
-        top: 3px;
-        left: 3px;
-        right: 3px;
-        bottom: 3px;
-        border-radius: 6px;
-        background: var(--option-color);
-        background-image: var(--option-color-image);
-        background-size: cover; }
-      .product-card-swatches .product-card-swatch.active {
-        box-shadow: 0 0 0 1px var(--color-accent) inset; }
+      padding: 0; }
+      .product-card-swatch-item.active .product-card-swatch {
+        border: 1px solid #DBD5C9; }
+    .product-card-swatches .product-card-swatch {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      width: 100%;
+      padding: 6px 8px;
+      margin: 0;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      background: transparent;
+      cursor: pointer;
+      text-align: left;
+      font-family: inherit;
+      font-size: 0.8125rem;
+      line-height: 1.2;
+      color: var(--color-body);
+      transition: border-color 0.25s cubic-bezier(0.104, 0.204, 0.492, 1); }
+      .product-card-swatches .product-card-swatch:hover {
+        border-color: rgba(219, 213, 201, 0.5); }
+      .product-card-swatches .product-card-swatch:focus {
+        outline: 2px solid var(--color-accent);
+        outline-offset: 2px; }
+    .product-card-swatch-circle {
+      display: block;
+      width: 20px;
+      height: 20px;
+      min-width: 20px;
+      border-radius: 50%;
+      background: var(--option-color);
+      background-image: var(--option-color-image);
+      background-size: cover;
+      background-position: center;
+      border: 1px solid rgba(0, 0, 0, 0.1); }
+    .product-card-swatch-name {
+      flex: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap; }
     .product-card-swatches--container {
       position: relative;
-      overflow: hidden;
-      height: 18px;
+      overflow: visible;
       margin-top: 10px; }
     .product-card-swatches--title {
       font-size: 0.8125rem;
@@ -413,6 +438,12 @@
     .product-card-swatches--always {
       position: static;
       transform: none; }
+    @media only screen and (max-width: 767px) {
+      .product-card-swatches {
+        position: static;
+        transform: none; }
+      .product-card-swatches--container {
+        overflow: visible; } }
   .product-card--add-to-cart-button {
     width: 100%;
     margin-top: 15px; }

--- a/locales/de.json
+++ b/locales/de.json
@@ -121,6 +121,7 @@
         "one": "Erhältlich in {{ count }} Farbe",
         "other": "Erhältlich in {{ count }} Farben"
       },
+      "color_swatch_label": "{{ color }} Farbvariante auswählen",
       "shipping_policy_html": "<a href=\"{{ link }}\">Versand<\/a> wird beim Checkout berechnet",
       "quantity": {
         "label": "Anzahl",

--- a/locales/en.default.json
+++ b/locales/en.default.json
@@ -130,6 +130,7 @@
         "one": "Available in {{ count }} color",
         "other": "Available in {{ count }} colors"
       },
+      "color_swatch_label": "Select {{ color }} color variant",
       "shipping_policy_html": "<a href=\"{{ link }}\">Shipping</a> calculated at checkout.",
       "quantity": {
         "label": "Quantity",

--- a/locales/es.json
+++ b/locales/es.json
@@ -121,6 +121,7 @@
         "one": "Disponible en {{ count }} color",
         "other": "Disponible en {{ count }} colores"
       },
+      "color_swatch_label": "Seleccionar variante de color {{ color }}",
       "shipping_policy_html": "Los <a href=\"{{ link }}\">gastos de envío<\/a> se calculan en la pantalla de pago.",
       "quantity": {
         "label": "Quantity",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -123,6 +123,7 @@
         "one": "Disponible en {{ count }} couleur",
         "other": "Disponible en {{ count }} couleurs"
       },
+      "color_swatch_label": "Sélectionner la variante de couleur {{ color }}",
       "shipping_policy_html": "<a href=\"{{ link }}\">Frais d'expédition<\/a> calculés à l'étape de paiement.",
       "quantity": {
         "label": "Quantité",

--- a/locales/it.json
+++ b/locales/it.json
@@ -122,6 +122,7 @@
         "one": "Disponibile in {{ count }} colore",
         "other": "Disponibile in {{ count }} colori"
       },
+      "color_swatch_label": "Seleziona variante di colore {{ color }}",
       "shipping_policy_html": "<a href=\"{{ link }}\">Spese di spedizione<\/a> calcolate al check-out.",
       "quantity": {
         "label": "Quantità",

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -121,6 +121,7 @@
         "one": "Verkrijgbaar in {{ count }} kleur",
         "other": "Verkrijgbaar in {{ count }} kleuren"
       },
+      "color_swatch_label": "Selecteer {{ color }} kleurvariant",
       "shipping_policy_html": "<a href=\"{{ link }}\">Verzendkosten</a> worden berekend bij de checkout.",
       "quantity": {
         "label": "Aantal",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -122,6 +122,7 @@
         "one": "{{ count }} renkte mevcut",
         "other": "{{ count }} renkte mevcut"
       },
+      "color_swatch_label": "{{ color }} renk seçeneğini seçin",
       "shipping_policy_html": "<a href=\"{{ link }}\">Kargo</a>, ödeme sayfasında hesaplanır.",
       "quantity": {
         "label": "Adet",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -121,6 +121,7 @@
         "one": "提供 {{ count }} 种颜色",
         "other": "提供 {{ count }} 种颜色"
       },
+      "color_swatch_label": "选择{{ color }}颜色变体",
       "shipping_policy_html": "结账时计算的<a href=\"{{ link }}\">运费</a>。",
       "quantity": {
         "label": "数量",

--- a/snippets/product-card-swatch.liquid
+++ b/snippets/product-card-swatch.liquid
@@ -36,10 +36,11 @@
 				-%}
 				{% if option.values.size > 1 %}
 				<div class="product-card-swatches--container no-js-hidden">
-					<div class="product-card-swatches product-card-swatches--{{ settings.swatch_style }}" data-index="{{ color_index }}">
+					<ul class="product-card-swatches product-card-swatches--{{ settings.swatch_style }}" data-index="{{ color_index }}" role="list">
 						{%- for value in option.values -%}
 							{%- liquid
 								assign active = ''
+								assign is_selected = false
 								assign variant_image = blank
 								assign variant_url = ''
 								assign srcset = ''
@@ -48,6 +49,7 @@
 									if variant.title contains value
 										if variant.image.id and variant.image.id == product.featured_image.id
 											assign active = 'active'
+											assign is_selected = true
 										endif
 										if variant.image
 											assign variant_image = variant.image
@@ -95,13 +97,21 @@
 									assign color_value = 'rgb(' | append: value.swatch.color.rgb | append: ')'
 								endif
 							-%}
-							<div class="product-card-swatch {{ active }}" style="--option-color: {{ color_value | downcase | escape }}; {%- if bg_value -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}" data-srcset="{{- srcset | slice: 0, l | strip_newlines -}}" data-href="{{ variant_url }}">
-								<span class="visually-hidden" for="{{ section.id }}-{{ option.position }}-{{ forloop.index0 }}">
-									{{ value }}
-								</span>
-							</div>
+							<li class="product-card-swatch-item {{ active }}" role="listitem">
+								<button 
+									class="product-card-swatch" 
+									type="button"
+									style="--option-color: {{ color_value | downcase | escape }}; {%- if bg_value -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}" 
+									data-srcset="{{- srcset | slice: 0, l | strip_newlines -}}" 
+									data-href="{{ variant_url }}"
+									aria-label="{{ 'products.product.color_swatch_label' | t: color: value }}"
+									aria-checked="{{ is_selected }}">
+									<span class="product-card-swatch-circle" aria-hidden="true"></span>
+									<span class="product-card-swatch-name">{{ value }}</span>
+								</button>
+							</li>
 						{%- endfor -%}
-					</div>
+					</ul>
 					{%- if swatch_style == 'hover' -%}
 						<div class="product-card-swatches--title">{{ 'products.product.available' | t: count: option.values.size }}</div>
 					{%- endif -%}


### PR DESCRIPTION
Refactor product grid color swatch selector to display as a vertical list with color name, enhance accessibility, and apply active state styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-d05128b3-c5fb-46c4-91fd-615a78cba1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d05128b3-c5fb-46c4-91fd-615a78cba1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Redesigns product-card color swatches into a vertical, accessible button list with updated styles, JS active-state handling, and new i18n labels.
> 
> - **Frontend/UI**:
>   - Refactors product-card swatches into a vertical list with button items in `snippets/product-card-swatch.liquid` using semantic `ul/li/button` and ARIA (`aria-label`, `aria-checked`).
>   - Updates `assets/app.js` hover/selection logic to toggle `.product-card-swatch-item.active`, set image `srcset`, and read `.product-card-swatch-name`.
> - **Styles**:
>   - Adds and styles `product-card-swatch-item`, `product-card-swatch`, `product-card-swatch-circle`, `product-card-swatch-name`; adjusts `.product-card-swatches` layout, hover/focus, active border, and mobile behavior in `assets/product-grid.css`.
> - **Internationalization**:
>   - Introduces `products.product.color_swatch_label` across `locales/*.json` (en, de, es, fr, it, nl, tr, zh-CN) for accessible labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e51789397b753093fb0570545f21af1f96fd6d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->