### PR TITLE
Button aria-checked attribute

### DIFF
--- a/snippets/product-card-swatch.liquid
+++ b/snippets/product-card-swatch.liquid
@@ -36,7 +36,7 @@
 				-%}
 				{% if option.values.size > 1 %}
 				<div class="product-card-swatches--container no-js-hidden">
-					<ul class="product-card-swatches product-card-swatches--{{ settings.swatch_style }}" data-index="{{ color_index }}" role="list">
+					<ul class="product-card-swatches product-card-swatches--{{ settings.swatch_style }}" data-index="{{ color_index }}" role="radiogroup" aria-label="{{ option.name }}">
 						{%- for value in option.values -%}
 							{%- liquid
 								assign active = ''
@@ -97,10 +97,11 @@
 									assign color_value = 'rgb(' | append: value.swatch.color.rgb | append: ')'
 								endif
 							-%}
-							<li class="product-card-swatch-item {{ active }}" role="listitem">
+							<li class="product-card-swatch-item {{ active }}">
 								<button 
 									class="product-card-swatch" 
 									type="button"
+									role="radio"
 									style="--option-color: {{ color_value | downcase | escape }}; {%- if bg_value -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}" 
 									data-srcset="{{- srcset | slice: 0, l | strip_newlines -}}" 
 									data-href="{{ variant_url }}"


### PR DESCRIPTION
Fix invalid `aria-checked` on buttons by implementing the ARIA radio button pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cf03231-6296-46a4-adec-a0d4d640e7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cf03231-6296-46a4-adec-a0d4d640e7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements ARIA radio button pattern for product-card color swatches by converting the swatch list into a radiogroup with radio buttons and correct aria-checked handling.
> 
> - **Accessibility (ARIA)**
>   - In `snippets/product-card-swatch.liquid`:
>     - Set `role="radiogroup"` and `aria-label` on the `ul` containing swatches.
>     - Removed `role="listitem"` from each `li`.
>     - Added `role="radio"` to each swatch `button` and now set `aria-checked` based on selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b87bb889d92bf14fa89ba3a29c4dff7c65fa75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->