### PR TITLE
Radiogroup li role attribute

### DIFF
--- a/snippets/product-card-swatch.liquid
+++ b/snippets/product-card-swatch.liquid
@@ -97,7 +97,7 @@
 									assign color_value = 'rgb(' | append: value.swatch.color.rgb | append: ')'
 								endif
 							-%}
-							<li class="product-card-swatch-item {{ active }}">
+							<li class="product-card-swatch-item {{ active }}" role="none">
 								<button 
 									class="product-card-swatch" 
 									type="button"


### PR DESCRIPTION
Add `role="none"` to an intermediate `<li>` element in `product-card-swatch.liquid` to correctly implement the ARIA radiogroup pattern.

According to ARIA specifications, a `radiogroup` must own only `radio` elements. Intermediate `<li>` elements require `role="none"` to be transparent to the accessibility tree, ensuring assistive technologies properly associate radio buttons with their radiogroup container. This fix aligns with existing patterns in the codebase (e.g., `header-mega-menu.liquid`).

---
<a href="https://cursor.com/background-agent?bcId=bc-05c1fa96-004c-40da-bfb2-d8e155afadae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05c1fa96-004c-40da-bfb2-d8e155afadae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add role="none" to intermediate <li> in snippets/product-card-swatch.liquid to ensure radiogroup only owns radio buttons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a9025aa0bc2e3928f148636bac7141716573ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->