### PR TITLE
Product color swatch layout

### DIFF
--- a/assets/facets.css
+++ b/assets/facets.css
@@ -445,12 +445,12 @@
 
 .thb-filter ul.list-color {
   display: flex;
-  flex-wrap: wrap;
-  padding: 1px 0 0 1px; }
+  flex-direction: column;
+  gap: 8px;
+  padding: 0; }
   .thb-filter ul.list-color li {
-    display: inline-flex;
-    margin-left: -1px;
-    margin-top: -1px; }
+    display: flex;
+    width: 100%; }
   .thb-filter ul.list-color input {
     clip: rect(0, 0, 0, 0);
     overflow: hidden;
@@ -458,51 +458,65 @@
     height: 1px;
     width: 1px; }
     .thb-filter ul.list-color input:checked + label {
-      z-index: 5;
-      box-shadow: 0 0 0 1px var(--color-body) inset; }
-    .thb-filter ul.list-color input:disabled + label:before {
-      content: ""; }
-    .thb-filter ul.list-color input:disabled + label:after {
-      opacity: 0.4; }
+      border: 1px solid #DBD5C9;
+      background-color: rgba(219, 213, 201, 0.05); }
+    .thb-filter ul.list-color input:disabled + label {
+      cursor: not-allowed;
+      opacity: 0.5; }
+      .thb-filter ul.list-color input:disabled + label:before {
+        position: relative; }
+      .thb-filter ul.list-color input:disabled + label:after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        left: 12px;
+        width: 28px;
+        height: 1px;
+        background: var(--color-border);
+        transform: translateY(-50%) rotate(-45deg);
+        pointer-events: none; }
     .thb-filter ul.list-color input:focus-visible + label {
-      transform: scale(0.9);
-      box-shadow: 0 0 0 2px #015ecc inset; }
+      outline: 2px solid #015ecc;
+      outline-offset: 2px; }
   .thb-filter ul.list-color label {
-    width: 48px;
-    height: 48px;
-    display: inline-flex;
-    text-indent: -9999em;
+    width: 100%;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
     position: relative;
     cursor: pointer;
-    color: transparent;
-    z-index: 4;
-    box-shadow: 0 0 0 1px var(--color-border) inset;
-    position: relative;
-    z-index: 0; }
+    color: var(--color-body);
+    font-size: 0.875rem;
+    border: 1px solid var(--color-border);
+    border-radius: 4px;
+    background-color: transparent;
+    transition: all 0.25s cubic-bezier(0.104, 0.204, 0.492, 1); }
     .thb-filter ul.list-color label:before {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      background: linear-gradient(to bottom left, transparent calc(50% - 1px), var(--color-border), transparent calc(50% + 1px)) no-repeat;
-      z-index: 1; }
-    .thb-filter ul.list-color label:after {
       content: "";
       display: block;
-      position: absolute;
-      top: 14px;
-      left: 14px;
-      right: 14px;
-      bottom: 14px;
+      flex-shrink: 0;
+      width: 28px;
+      height: 28px;
       border-radius: 50%;
-      background-size: cover;
       background-color: var(--bg-color, "black");
-      background-image: var(--option-color-image); }
-    .thb-filter ul.list-color label:hover:after {
-      transform: scale(0.9); }
+      background-image: var(--option-color-image);
+      background-size: cover;
+      background-position: center;
+      border: 1px solid rgba(var(--color-body-rgb), 0.1);
+      order: -1; }
+    .thb-filter ul.list-color label:after {
+      display: none; }
+    .thb-filter ul.list-color label:hover {
+      border-color: var(--color-body);
+      background-color: rgba(var(--color-body-rgb), 0.02); }
     .thb-filter ul.list-color label:not(.facet-checkbox--disabled):hover {
-      z-index: 1;
-      box-shadow: 0 0 0 1px var(--color-body) inset; }
+      transform: none; }
+    .thb-filter ul.list-color label .count {
+      margin-left: auto;
+      font-size: 0.75rem;
+      color: rgba(var(--color-body-rgb), 0.6); }
 
 .thb-filter ul.list--boxed {
   display: grid;

--- a/snippets/facets-desktop.liquid
+++ b/snippets/facets-desktop.liquid
@@ -137,8 +137,11 @@
 																	class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
 																	style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
 																	data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																	aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																	role="checkbox"
+																	aria-checked="{% if value.active %}true{% else %}false{% endif %}"
 																>
-																	{{ value.label | escape }} {% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
+																	<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																</label>
 															{%- else -%}
 																{%- liquid
@@ -161,8 +164,11 @@
 																	class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
 																	style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
 																	data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																	aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																	role="checkbox"
+																	aria-checked="{% if value.active %}true{% else %}false{% endif %}"
 																>
-																	{{ value.label | escape }} {% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
+																	<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																</label>
 															{%- endif -%}
 									          </li>

--- a/snippets/facets-mobile.liquid
+++ b/snippets/facets-mobile.liquid
@@ -170,8 +170,11 @@
 																			class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
 																			style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
 																			data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																			aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																			role="checkbox"
+																			aria-checked="{% if value.active %}true{% else %}false{% endif %}"
 																		>
-																			{{ value.label | escape }} {% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
+																			<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																		</label>
 																	{%- else -%}
 																		{%- liquid
@@ -194,8 +197,11 @@
 																			class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
 																			style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
 																			data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																			aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																			role="checkbox"
+																			aria-checked="{% if value.active %}true{% else %}false{% endif %}"
 																		>
-																			{{ value.label | escape }} {% if show_counts %}<span class="count">({{ value.count }})</span>{% endif %}
+																			<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts %}<span class="count">({{ value.count }})</span>{% endif %}
 																		</label>
 																	{%- endif -%}
 																</li>


### PR DESCRIPTION
Refactor `.list-color` to display color swatches as a vertical list with enhanced accessibility and styling.

This change transforms the color swatch display from a horizontal grid to a modern vertical list, improving user experience and accessibility. Each swatch now clearly shows the color on the left and its name on the right, with distinct styling for active and disabled states, and improved ARIA attributes for screen readers.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cf23c4c-5c23-4b3c-9747-77a2b47f91e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cf23c4c-5c23-4b3c-9747-77a2b47f91e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors color swatch filters to a vertical list with updated styling and ARIA attributes across desktop and mobile.
> 
> - **Facets UI (CSS)**:
>   - Convert `ul.list-color` from grid-like chips to a vertical, full-width list with gaps; new label layout, borders, hover/active/disabled states, and focus outlines.
>   - Render swatch as a circular preview via `label:before`; right-align count; adjust checked/disabled visuals and background handling.
> - **Templates (desktop/mobile)**:
>   - Add `aria-label`, `role="checkbox"`, and `aria-checked` to color swatch labels; wrap text in `span.facet-checkbox__text` and standardize count markup.
>   - Apply same a11y/styling hooks for both swatch-presented and non-swatch color options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed16d0dfb976fc3c9d43b5a7af0e12dce3e552c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->