### PR TITLE
Accessibility and styling fixes

### DIFF
--- a/assets/facets.css
+++ b/assets/facets.css
@@ -467,6 +467,7 @@
         position: relative; }
       .thb-filter ul.list-color input:disabled + label:after {
         content: "";
+        display: block;
         position: absolute;
         top: 50%;
         left: 12px;

--- a/snippets/facets-desktop.liquid
+++ b/snippets/facets-desktop.liquid
@@ -132,15 +132,13 @@
 																	endif
 
 																-%}
-																<label
-																	for="Filter-{{ label }}-{{ forloop.index }}"
-																	class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
-																	style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
-																	data-tooltip="{{ value.label | escape }} ({{ value.count }})"
-																	aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
-																	role="checkbox"
-																	aria-checked="{% if value.active %}true{% else %}false{% endif %}"
-																>
+															<label
+																for="Filter-{{ label }}-{{ forloop.index }}"
+																class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
+																style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
+																data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+															>
 																	<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																</label>
 															{%- else -%}
@@ -159,15 +157,13 @@
 																	assign color_value = 'var(--bg-body)'
 																endif
 																-%}
-																<label
-																	for="Filter-{{ label }}-{{ forloop.index }}"
-																	class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
-																	style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
-																	data-tooltip="{{ value.label | escape }} ({{ value.count }})"
-																	aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
-																	role="checkbox"
-																	aria-checked="{% if value.active %}true{% else %}false{% endif %}"
-																>
+															<label
+																for="Filter-{{ label }}-{{ forloop.index }}"
+																class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
+																style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
+																data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+															>
 																	<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																</label>
 															{%- endif -%}

--- a/snippets/facets-mobile.liquid
+++ b/snippets/facets-mobile.liquid
@@ -165,15 +165,13 @@
 																			endif
 
 																		-%}
-																		<label
-																			for="Filter-Mobile-{{ label }}-{{ forloop.index }}"
-																			class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
-																			style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
-																			data-tooltip="{{ value.label | escape }} ({{ value.count }})"
-																			aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
-																			role="checkbox"
-																			aria-checked="{% if value.active %}true{% else %}false{% endif %}"
-																		>
+																	<label
+																		for="Filter-Mobile-{{ label }}-{{ forloop.index }}"
+																		class="facet-checkbox facet-checkbox--presentation{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
+																		style="--bg-color: {{ color_value }}; {%- unless bg_value == empty -%}--option-color-image: url('{{ bg_value }}'){%- endunless -%};"
+																		data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																		aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																	>
 																			<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts -%}<sup class="count">{{ value.count }}</sup>{%- endif -%}
 																		</label>
 																	{%- else -%}
@@ -192,15 +190,13 @@
 																				assign color_value = 'var(--bg-body)'
 																			endif
 																		-%}
-																		<label
-																			for="Filter-Mobile-{{ label }}-{{ forloop.index }}"
-																			class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
-																			style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
-																			data-tooltip="{{ value.label | escape }} ({{ value.count }})"
-																			aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
-																			role="checkbox"
-																			aria-checked="{% if value.active %}true{% else %}false{% endif %}"
-																		>
+																	<label
+																		for="Filter-Mobile-{{ label }}-{{ forloop.index }}"
+																		class="facet-checkbox{% if value.count == 0 and value.active == false %} facet-checkbox--disabled{% endif %}"
+																		style="--bg-color: {{ color_value | downcase | escape }};{%- if bg_value != blank -%} --option-color-image: url('{{ bg_value | escape }}');{%- endif -%}"
+																		data-tooltip="{{ value.label | escape }} ({{ value.count }})"
+																		aria-label="{{ value.label | escape }}{% if show_counts %} - {{ value.count }} {{ 'products.facets.product_count_simple' | t: count: value.count }}{% endif %}"
+																	>
 																			<span class="facet-checkbox__text">{{ value.label | escape }}</span>{% if show_counts %}<span class="count">({{ value.count }})</span>{% endif %}
 																		</label>
 																	{%- endif -%}


### PR DESCRIPTION
Remove duplicate `role="checkbox"` from labels and fix hidden disabled strikethrough indicator to improve accessibility and UI.

The `role="checkbox"` and `aria-checked` attributes on `<label>` elements associated with native `<input type="checkbox">` elements caused screen readers to announce two checkboxes, leading to confusion. Per ARIA guidelines, `role="checkbox"` is only for non-native elements. Additionally, a `display: none` rule on `label:after` was preventing the strikethrough for disabled color swatches from being visible, as the more specific disabled rule did not explicitly override the `display` property.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ca0e5a2-99c3-4db8-b753-831546c8e4b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ca0e5a2-99c3-4db8-b753-831546c8e4b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `role="checkbox"`/`aria-checked` from facet labels and ensures disabled color swatches display a visible strikethrough.
> 
> - **Accessibility**
>   - Remove `role="checkbox"` and `aria-checked` from facet `label` elements in `snippets/facets-desktop.liquid` and `snippets/facets-mobile.liquid` to rely on native inputs.
> - **Styles**
>   - In `assets/facets.css`, ensure disabled color swatches show the strikethrough by adding `display: block` to `input:disabled + label:after` under `ul.list-color`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44ce7c75137da29d6b4760df4d2f6d9a1caac23f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->